### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,4 +1,6 @@
 name: Python CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/joanalnu/gen10/security/code-scanning/2](https://github.com/joanalnu/gen10/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Based on the workflow's tasks, the minimal required permissions are `contents: read`, as the workflow only needs to read the repository contents to build the Docker image and run tests.

The `permissions` block should be added immediately after the `name` field (line 1) to ensure it applies globally to the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
